### PR TITLE
Scripts to upsert datasets in staging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ gem "byebug"
 gem "rb-readline"
 gem "roo", ">= 2.8.2"
 gem "roo-xls", ">= 1.2.0"
+gem 'faraday'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  faraday
   gobierto_data!
   rb-readline
   roo (>= 2.8.2)

--- a/lib/gobierto_data/client.rb
+++ b/lib/gobierto_data/client.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+Bundler.require
+
+module GobiertoData
+  class Client
+
+    class ServerError < StandardError; end
+
+    attr_accessor(
+      :gobierto_url,
+      :auth_header,
+      :debug,
+      :no_verify_ssl
+    )
+
+    def initialize(params = {})
+      self.gobierto_url = params[:gobierto_url]
+      self.debug = params[:debug] || false
+      self.no_verify_ssl = params[:no_verify_ssl]
+
+      raise "API token can't be blank" unless params[:api_token].present?
+      self.auth_header = "Bearer #{params[:api_token]}"
+    end
+
+    def create_dataset(params = {})
+      multipart = params[:file_path].present? || params[:schema_path].present?
+      response = connection(multipart).post(
+        "api/v1/data/datasets",
+        build_dataset_params(multipart, params),
+        build_dataset_request_headers(multipart)
+      )
+      log_response(response) if debug
+      if response.status >= 300
+        raise ServerError, response.status
+      end
+      response
+    end
+
+    def update_dataset(params = {})
+      multipart = params[:file_path].present? || params[:schema_path].present?
+      response = connection(multipart).put(
+        "api/v1/data/datasets/#{params[:slug]}",
+        build_dataset_params(multipart, params),
+        build_dataset_request_headers(multipart)
+      )
+      log_response(response) if debug
+      if response.status >= 300
+        raise ServerError, response.status
+      end
+      response
+    end
+
+    def upsert_dataset(params = {})
+      response = connection.get(
+        "api/v1/data/datasets/#{params[:slug]}/meta",
+        nil,
+        build_dataset_request_headers(false)
+      )
+      log_response(response) if debug
+
+      response = if response.status == 200
+        update_dataset(params)
+      elsif response.status == 404
+        create_dataset(params)
+      else
+        raise ServerError, response.status
+      end
+
+      if response.status >= 300
+        log_response(response) if debug
+        raise ServerError, response.status
+      end
+    end
+
+    private
+
+    def log_response(response)
+      puts "#{response.env.method.upcase} #{response.env.url} ===> #{response.status}"
+      puts "\tBODY: #{response.body}" if (response.status < 200 || response.status > 299)
+    end
+
+    def connection(multipart = false)
+      @connection = begin
+                      options = { request: { timeout: 600 } }
+                      options.merge!(ssl: { verify: false }) if no_verify_ssl
+                      Faraday.new(gobierto_url, options) do |f|
+                        f.request(:multipart ) if multipart
+                        f.request :url_encoded
+                        f.adapter :net_http
+                      end
+                    end
+    end
+
+    def build_dataset_params(multipart, params = {})
+      dataset_params = {
+        name: params[:name],
+        table_name: params[:table_name],
+        slug: params[:slug],
+        local_data: false,
+        visibility_level: params[:visibility_level],
+        csv_separator: params[:csv_separator] || ",",
+        append: params[:append] || false
+      }
+
+      dataset_params.merge!({data_path: params[:file_url]}) if params[:file_url]
+      dataset_params.merge!({data_file: Faraday::UploadIO.new(params[:file_path], "text/csv")}) if params[:file_path]
+      dataset_params.merge!({schema_file: Faraday::UploadIO.new(params[:schema_path], "application/json")}) if params[:schema_path]
+
+      if multipart
+        {dataset: dataset_params}
+      else
+        dataset_params = {
+          data: {
+            type: "gobierto_data-dataset_forms",
+            attributes: dataset_params
+          }
+        }
+        dataset_params.to_json
+      end
+    end
+
+    def build_dataset_request_headers(multipart)
+      default_headers = {
+        "Authorization" => auth_header
+      }
+      default_headers.merge!({"Content-Type" => "application/json"}) unless multipart
+      default_headers
+    end
+  end
+end

--- a/scripts/datasets/contratos/run.rb
+++ b/scripts/datasets/contratos/run.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+
+require 'uri'
+require "bundler/setup"
+Bundler.require
+
+require_relative '../../../lib/gobierto_data/client'
+
+DIPHU_CODE = "21041"
+ETL_UTILS="/home/populate/gobierto-etl-utils"
+GOBIERTO_DATA_DEST_URL= "https://des-presupuestos.diphuelva.es"
+GOBIERTO_DATA_SOURCE_URL= "https://datos.gobierto.es"
+DATASET_NAME = "Contratos"
+DATASET_SLUG = "contratos"
+DATASET_TABLE_NAME = "contratos"
+
+raw_query_source = File.read File.join(ETL_UTILS, "operations", "gobierto_data", "extract-contracts", "query.sql")
+query = raw_query_source.gsub("<PLACE_ID>", DIPHU_CODE)
+query = query.gsub("\n", ' ').gsub(/\s{1,}/, '+').strip
+file_url = URI::join(GOBIERTO_DATA_SOURCE_URL, "/api/v1/data/data.csv?token=#{ENV.fetch('READ_API_TOKEN')}&sql=#{query}").to_s
+
+options = {
+  api_token: ENV.fetch('WRITE_API_TOKEN'),
+  gobierto_url: GOBIERTO_DATA_DEST_URL,
+  debug: true,
+  no_verify_ssl: true,
+  name: DATASET_NAME,
+  slug: DATASET_SLUG,
+  table_name: DATASET_TABLE_NAME,
+  schema_path: File.join(ETL_UTILS, "/operations/gobierto_data/extract-contracts/schema.json"),
+  file_url: file_url,
+  visibility_level: 'active'
+}
+
+gobierto_data_client = GobiertoData::Client.new(options.slice(:api_token, :gobierto_url, :debug, :no_verify_ssl))
+gobierto_data_client.upsert_dataset(options.except(:api_token, :gobierto_url, :debug))

--- a/scripts/datasets/licitaciones/run.rb
+++ b/scripts/datasets/licitaciones/run.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+
+require 'uri'
+require "bundler/setup"
+Bundler.require
+
+require_relative '../../../lib/gobierto_data/client'
+
+DIPHU_CODE = "21041"
+ETL_UTILS="/home/populate/gobierto-etl-utils"
+GOBIERTO_DATA_DEST_URL= "https://des-presupuestos.diphuelva.es"
+GOBIERTO_DATA_SOURCE_URL= "https://datos.gobierto.es"
+DATASET_NAME = "Licitaciones"
+DATASET_SLUG = "licitaciones"
+DATASET_TABLE_NAME = "licitaciones"
+
+raw_query_source = File.read File.join(ETL_UTILS, "operations", "gobierto_data", "extract-tenders", "query.sql")
+query = raw_query_source.gsub("<PLACE_ID>", DIPHU_CODE)
+query = query.gsub("\n", ' ').gsub(/\s{1,}/, '+').strip
+file_url = URI::join(GOBIERTO_DATA_SOURCE_URL, "/api/v1/data/data.csv?token=#{ENV.fetch('READ_API_TOKEN')}&sql=#{query}").to_s
+
+options = {
+  api_token: ENV.fetch('WRITE_API_TOKEN'),
+  gobierto_url: GOBIERTO_DATA_DEST_URL,
+  debug: true,
+  no_verify_ssl: true,
+  name: DATASET_NAME,
+  slug: DATASET_SLUG,
+  table_name: DATASET_TABLE_NAME,
+  schema_path: File.join(ETL_UTILS, "/operations/gobierto_data/extract-tenders/schema.json"),
+  file_url: file_url,
+  visibility_level: 'active'
+}
+
+gobierto_data_client = GobiertoData::Client.new(options.slice(:api_token, :gobierto_url, :debug, :no_verify_ssl))
+gobierto_data_client.upsert_dataset(options.except(:api_token, :gobierto_url, :debug))


### PR DESCRIPTION
related to PopulateTools/issues#1259

Scripts to upload tenders & contracts datasets to staging. These must be run from the diphu staging server.

The datasets are loaded: https://des-presupuestos.diphuelva.es/api/v1/data/data.csv?sql=select%20*%20from%20licitaciones (urls need VPN)