### PR TITLE
1352 rename gobierto data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "gobierto_data", git: "https://github.com/PopulateTools/gobierto_data.git"
+gem "gobierto_budgets_data", git: "https://github.com/PopulateTools/gobierto_budgets_data.git"
 gem "byebug"
 gem "rb-readline"
 gem "roo", ">= 2.8.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
-  remote: https://github.com/PopulateTools/gobierto_data.git
-  revision: 9798139a06e30999302a0e43fb02b06ce4e5f357
+  remote: https://github.com/PopulateTools/gobierto_budgets_data.git
+  revision: 7db1fa4d63f08ca30d334255469144bdbc246673
   specs:
-    gobierto_data (0.1.0)
+    gobierto_budgets_data (0.1.0)
       actionpack
       activesupport
       aws-sdk-s3
@@ -120,7 +120,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  gobierto_data!
+  gobierto_budgets_data!
   rb-readline
   roo (>= 2.8.2)
   roo-xls (>= 1.2.0)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ETL scripts for Gobierto Diputacion Huelva site
 
 Edit `.env.example` and copy it to `.env` or `.rbenv-vars` with the expected values.
 
-This repository relies heavily in [gobierto_data](https://github.com/PopulateTools/gobierto_data)
+This repository relies heavily in [gobierto_budgets_data](https://github.com/PopulateTools/gobierto_budgets_data)
 
 ## Available operations
 

--- a/operations/gobierto_budgets/extract-custom-categories/run.rb
+++ b/operations/gobierto_budgets/extract-custom-categories/run.rb
@@ -28,7 +28,7 @@ end
 input_file = ARGV[0]
 csv_mappings = CSV.read(ARGV[1], headers: true)
 output_file = ARGV[2]
-kind = GobiertoData::GobiertoBudgets::EXPENSE
+kind = GobiertoBudgetsData::GobiertoBudgets::EXPENSE
 
 puts "[START] extract-custom-categories/run.rb with file=#{input_file} and mapping_file=#{ARGV[1]}"
 

--- a/operations/gobierto_budgets/import-budgets/run.rb
+++ b/operations/gobierto_budgets/import-budgets/run.rb
@@ -6,13 +6,14 @@ Bundler.require
 data_file = ARGV[0]
 year = ARGV[0].match(/\/(\d{4})/)[1].to_i
 index = if data_file.include?("ejecucion")
-          GobiertoData::GobiertoBudgets::ES_INDEX_EXECUTED
+          GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_EXECUTED
         else
-          GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST
+          GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST
         end
 
 puts "[START] import-budgets/run.rb year=#{year} data_file=#{data_file} index=#{index}"
 
-nitems = GobiertoData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year, data: JSON.parse(File.read(data_file))).import!
+nitems = GobiertoBudgetsData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year,
+                                                                       data: JSON.parse(File.read(data_file))).import!
 
 puts "[END] import-budgets/run.rb imported #{nitems} items"

--- a/operations/gobierto_budgets/import-custom-categories/run.rb
+++ b/operations/gobierto_budgets/import-custom-categories/run.rb
@@ -26,14 +26,15 @@ end
 
 input_file = ARGV[0]
 INE_CODE = '21000'
-kind = ARGV[0].include?("ingresos") ? GobiertoData::GobiertoBudgets::INCOME : GobiertoData::GobiertoBudgets::EXPENSE
+kind = ARGV[0].include?('ingresos') ? GobiertoBudgetsData::GobiertoBudgets::INCOME : GobiertoBudgetsData::GobiertoBudgets::EXPENSE
 SITE = Site.find_by! domain: ARGV[1]
 
 puts "[START] import-custom-categories/run.rb with file=#{input_file} site=#{SITE.domain}"
 
 def create_or_update_category!(name, code, kind)
   name_translations = { "es" => name }
-  category_attrs = { site: SITE, area_name: GobiertoData::GobiertoBudgets::CUSTOM_AREA_NAME, kind: kind, code: code }
+  category_attrs = { site: SITE, area_name: GobiertoBudgetsData::GobiertoBudgets::CUSTOM_AREA_NAME, kind: kind,
+                     code: code }
 
   if (category = GobiertoBudgets::Category.where(category_attrs).first)
     category.update_attributes!(custom_name_translations: name_translations)

--- a/operations/gobierto_budgets/transform-budgets/run.rb
+++ b/operations/gobierto_budgets/transform-budgets/run.rb
@@ -27,7 +27,7 @@ end
 
 input_file = ARGV[0]
 output_file = ARGV[1]
-@kind = ARGV[0].include?("ingresos") ? GobiertoData::GobiertoBudgets::INCOME : GobiertoData::GobiertoBudgets::EXPENSE
+@kind = ARGV[0].include?('ingresos') ? GobiertoBudgetsData::GobiertoBudgets::INCOME : GobiertoBudgetsData::GobiertoBudgets::EXPENSE
 @year = ARGV[0].match(/(\d{4})/)[1].to_i
 @csv_mappings = Hash[CSV.read(ARGV[2], headers: true).map do |row|
   [row[0].to_i.to_s, row[2].to_i.to_s]
@@ -53,15 +53,15 @@ end
 
 def indexes
   @indexes ||= [
-    GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST
+    GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST
   ]
 end
 
 def areas
   @areas ||= [
-    GobiertoData::GobiertoBudgets::ECONOMIC_AREA_NAME,
-    GobiertoData::GobiertoBudgets::FUNCTIONAL_AREA_NAME,
-    GobiertoData::GobiertoBudgets::CUSTOM_AREA_NAME
+    GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME,
+    GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME,
+    GobiertoBudgetsData::GobiertoBudgets::CUSTOM_AREA_NAME
   ]
 end
 
@@ -69,7 +69,7 @@ def areas_with_levels
   if @year == Date.today.year
     areas
   else
-    areas - [GobiertoData::GobiertoBudgets::CUSTOM_AREA_NAME]
+    areas - [GobiertoBudgetsData::GobiertoBudgets::CUSTOM_AREA_NAME]
   end
 end
 
@@ -85,24 +85,24 @@ def parse_amount(s)
 end
 
 def process_row(row)
-  income = kind == GobiertoData::GobiertoBudgets::INCOME
+  income = kind == GobiertoBudgetsData::GobiertoBudgets::INCOME
   amounts = {
-    GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST => parse_amount(income ? row[3] : row[4])
+    GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST => parse_amount(income ? row[3] : row[4])
   }
   codes = {
-    GobiertoData::GobiertoBudgets::ECONOMIC_AREA_NAME => income ? row[1] : row[2],
-    GobiertoData::GobiertoBudgets::FUNCTIONAL_AREA_NAME => income ? nil : row[1],
-    GobiertoData::GobiertoBudgets::CUSTOM_AREA_NAME => income ? nil : [row[0], row[1], row[2]].join("-")
+    GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME => income ? row[1] : row[2],
+    GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME => income ? nil : row[1],
+    GobiertoBudgetsData::GobiertoBudgets::CUSTOM_AREA_NAME => income ? nil : [row[0], row[1], row[2]].join('-')
   }
 
-  return if codes[GobiertoData::GobiertoBudgets::ECONOMIC_AREA_NAME].nil?
+  return if codes[GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME].nil?
 
   indexes.each do |index|
     areas.each do |area|
       next if (code = codes[area]).nil?
 
       if areas_with_levels.include?(area)
-        code_levels = if area == GobiertoData::GobiertoBudgets::CUSTOM_AREA_NAME
+        code_levels = if area == GobiertoBudgetsData::GobiertoBudgets::CUSTOM_AREA_NAME
                         # TODO: remove default 9 when others are mapped properly
                         parent_code = @csv_mappings[code.split("-").first.to_i.to_s] || 9
                         [code, parent_code]
@@ -129,7 +129,7 @@ def hydratate(options)
     code = code.to_s
     level = nil
     parent_code = nil
-    if area_name == GobiertoData::GobiertoBudgets::CUSTOM_AREA_NAME
+    if area_name == GobiertoBudgetsData::GobiertoBudgets::CUSTOM_AREA_NAME
       level = code.include?("-") ? 2 : 1
       parent_code = if code.include?("-")
                       # TODO: remove default 9 when others are mapped properly
@@ -182,7 +182,7 @@ end
 normalize_data(data)
 
 output_files = {
-  GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST => output_file
+  GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST => output_file
 }
 
 output_files.each do |index, file_name|


### PR DESCRIPTION
Related to PopulateTools/issues#1352

This PR replaces namespaces of `GobiertoData` with `GobiertoBudgetsData` and updates the gems dependency to point `gobierto_budgets_data` instead of `gobierto_data`