### PR TITLE
Use clear-cache operation including site and namespace

### DIFF
--- a/Pipeline-budgets.sh
+++ b/Pipeline-budgets.sh
@@ -52,4 +52,4 @@ cd $GOBIERTO_DIR; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto_budge
 cd $GOBIERTO_DIR; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto/publish-activity/run.rb budgets_updated $WORKING_DIR/organization.id.txt
 
 # Clear cache
-cd $GOBIERTO_DIR; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto/clear-cache/run.rb
+cd $GOBIERTO_DIR; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto/clear-cache/run.rb --site-organization-id "$DIPHU_INE_CODE" --namespace "GobiertoBudgets"

--- a/Pipeline-invoices.sh
+++ b/Pipeline-invoices.sh
@@ -32,4 +32,4 @@ echo $DIPHU_INE_CODE > $WORKING_DIR/organization.id.txt
 cd $GOBIERTO_DIR; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto/publish-activity/run.rb providers_updated $WORKING_DIR/organization.id.txt
 
 # Clear cache
-cd $GOBIERTO_DIR; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto/clear-cache/run.rb
+cd $GOBIERTO_DIR; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto/clear-cache/run.rb --site-organization-id "$DIPHU_INE_CODE" --namespace "GobiertoBudgets"


### PR DESCRIPTION
Related to PopulateTools/issues#1439

This PR replaces the clear-cache operation call and includes site and namespace arguments